### PR TITLE
Enable Eslint no-inferrable-types Rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,9 +3,4 @@ module.exports = {
         project: './tsconfig.json',
     },
     extends: "@keetapay/eslint-config-typescript",
-    rules: {
-		'@typescript-eslint/no-inferrable-types': ['error', {
-			'ignoreParameters': true
-		}],
-	},
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@keetapay/pulumi-components",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "ISC",
       "dependencies": {
         "@pulumi/command": "0.7.0",
@@ -14,7 +14,7 @@
         "@pulumi/pulumi": "3.54.0"
       },
       "devDependencies": {
-        "@keetapay/eslint-config-typescript": "1.0.0",
+        "@keetapay/eslint-config-typescript": "1.0.2",
         "eslint": "8.33.0",
         "typescript": "4.9.5"
       }
@@ -118,9 +118,9 @@
       "dev": true
     },
     "node_modules/@keetapay/eslint-config-typescript": {
-      "version": "1.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@keetapay/eslint-config-typescript/1.0.0/531738c6f9902acb9116bad48f5af959e955077b",
-      "integrity": "sha512-SOB/epgY4YZK6w7KAMWPVpueNyGC1iYPL5KL7v3+g8qmBd7mf9WuzXJZ+T+++gIpl5NC3pSjeyx5NGlYJ/XaPQ==",
+      "version": "1.0.2",
+      "resolved": "https://npm.pkg.github.com/download/@keetapay/eslint-config-typescript/1.0.2/5bd67440a3dbdc0ce6d41e6ec87ea4b4f3244218",
+      "integrity": "sha512-4M8eRT7rOw+oM8dTtdCsbi/p8/i12fK7z5lFgnRYTw4L8RFrfkc3OtaF0Ydz0Tgl6CWFaVnQ/Re4qJwDcrwXnA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -128,7 +128,8 @@
         "@typescript-eslint/parser": "^5.51.0",
         "eslint": "^8.33.0",
         "eslint-config-airbnb": "^19.0.4",
-        "eslint-config-airbnb-typescript": "^17.0.0"
+        "eslint-config-airbnb-typescript": "^17.0.0",
+        "eslint-plugin-no-type-assertion": "^1.3.0"
       }
     },
     "node_modules/@logdna/tail-file": {
@@ -1636,6 +1637,19 @@
       },
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-no-type-assertion": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-type-assertion/-/eslint-plugin-no-type-assertion-1.3.0.tgz",
+      "integrity": "sha512-04wuuIP5ptNzp969tTt0gf/Jsw4G0T5md2/nbgv3dRL/HySSNU7H4vIKNjkuno9T+6h2daj1T9Aki6bDgmXDEw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0",
+        "yarn": "^1.13.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/eslint-plugin-react": {
@@ -4005,16 +4019,17 @@
       "dev": true
     },
     "@keetapay/eslint-config-typescript": {
-      "version": "1.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@keetapay/eslint-config-typescript/1.0.0/531738c6f9902acb9116bad48f5af959e955077b",
-      "integrity": "sha512-SOB/epgY4YZK6w7KAMWPVpueNyGC1iYPL5KL7v3+g8qmBd7mf9WuzXJZ+T+++gIpl5NC3pSjeyx5NGlYJ/XaPQ==",
+      "version": "1.0.2",
+      "resolved": "https://npm.pkg.github.com/download/@keetapay/eslint-config-typescript/1.0.2/5bd67440a3dbdc0ce6d41e6ec87ea4b4f3244218",
+      "integrity": "sha512-4M8eRT7rOw+oM8dTtdCsbi/p8/i12fK7z5lFgnRYTw4L8RFrfkc3OtaF0Ydz0Tgl6CWFaVnQ/Re4qJwDcrwXnA==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^5.51.0",
         "@typescript-eslint/parser": "^5.51.0",
         "eslint": "^8.33.0",
         "eslint-config-airbnb": "^19.0.4",
-        "eslint-config-airbnb-typescript": "^17.0.0"
+        "eslint-config-airbnb-typescript": "^17.0.0",
+        "eslint-plugin-no-type-assertion": "^1.3.0"
       }
     },
     "@logdna/tail-file": {
@@ -5150,6 +5165,13 @@
         "object.fromentries": "^2.0.6",
         "semver": "^6.3.0"
       }
+    },
+    "eslint-plugin-no-type-assertion": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-type-assertion/-/eslint-plugin-no-type-assertion-1.3.0.tgz",
+      "integrity": "sha512-04wuuIP5ptNzp969tTt0gf/Jsw4G0T5md2/nbgv3dRL/HySSNU7H4vIKNjkuno9T+6h2daj1T9Aki6bDgmXDEw==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-react": {
       "version": "7.32.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "eslint": "eslint"
   },
   "devDependencies": {
-    "@keetapay/eslint-config-typescript": "1.0.0",
+    "@keetapay/eslint-config-typescript": "1.0.2",
     "eslint": "8.33.0",
     "typescript": "4.9.5"
   },


### PR DESCRIPTION
No src code changes needed for this PR.

This change enables the @typescript-eslint/no-inferrable-types eslint rule. Looking at multiple sources it's generally recommended to not add types when it's easily inferable. For example instead of

const x: string = 'string';

It should be

const x = 'string';

An optional ignoreParameters=true setting allows types to still be defined in function parameters when a default is provided.

https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-inferrable-types.md