### PR TITLE
Cache tarballs generated from directories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@keetapay/pulumi-components",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@keetapay/pulumi-components",
-      "version": "1.0.37",
+      "version": "1.0.38",
       "license": "ISC",
       "dependencies": {
         "@google-cloud/cloudbuild": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keetapay/pulumi-components",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "description": "KeetaPay Pulumi Components",
   "repository": "https://github.com/keetapay/pulumi-components.git",
   "main": "dist/index.js",


### PR DESCRIPTION
This changeset adds support for caching tarballs created from directories based on a user-supplied cache tag, or the Image URI if a user supplied cache tag is not made available.  This means the tarball will not be regenerated if the URI does not change.