### PR TITLE
Fix typo in generating tarball canonical ID prefix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@keetapay/pulumi-components",
-  "version": "1.0.40",
+  "version": "1.0.41",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@keetapay/pulumi-components",
-      "version": "1.0.40",
+      "version": "1.0.41",
       "license": "ISC",
       "dependencies": {
         "@google-cloud/cloudbuild": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keetapay/pulumi-components",
-  "version": "1.0.40",
+  "version": "1.0.41",
   "description": "KeetaPay Pulumi Components",
   "repository": "https://github.com/keetapay/pulumi-components.git",
   "main": "dist/index.js",

--- a/src/packages/tarball.ts
+++ b/src/packages/tarball.ts
@@ -125,7 +125,7 @@ function createTarballFromGit(directory: string, commitID: string = 'HEAD'): { c
 	 * Get the canonical directory name, which is the path to the
 	 * directory within the git repository
 	 */
-	const canonicalDir = child_process.execSync('git rev-parse --prefix', {
+	const canonicalDir = child_process.execSync('git rev-parse --show-prefix', {
 		cwd: directory
 	}).toString().trim();
 	const dirHash = utils.hash(canonicalDir, 32);


### PR DESCRIPTION
Broken in #20, this fixes a bug where the command option used to get the directory suffix is incorrect.