### PR TITLE
Fix bug where docker builds using local docker will delete the source

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@keetapay/pulumi-components",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@keetapay/pulumi-components",
-      "version": "1.0.41",
+      "version": "1.0.42",
       "license": "ISC",
       "dependencies": {
         "@google-cloud/cloudbuild": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keetapay/pulumi-components",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "description": "KeetaPay Pulumi Components",
   "repository": "https://github.com/keetapay/pulumi-components.git",
   "main": "dist/index.js",

--- a/src/packages/docker.ts
+++ b/src/packages/docker.ts
@@ -354,7 +354,7 @@ export class LocalDockerImage extends BaseDockerImage {
 			buildArgs: buildArgs,
 			imageCache: this.imageCache,
 			tags: this.getDockerBuildTags(input),
-			cleanBuildDirectory: true
+			cleanBuildDirectory: false
 		});
 
 		return image.digest;


### PR DESCRIPTION
This changeset fixes a bug (added in #13) where a Docker build using a source directory as a string will delete the user-supplied directory because it unconditionally passes `cleanBuildDirectory` as `true` even when the `getBuildDirectory()` method didn't create a directory.

This isn't needed in any cases because there is already a method for cleaning up the created temporary directory called `clean()` which is tracking the temporary directory.