### PR TITLE
Fix some bugs with secretmanager replication within EnvManager

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@keetapay/pulumi-components",
-  "version": "1.0.60",
+  "version": "1.0.61",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@keetapay/pulumi-components",
-      "version": "1.0.60",
+      "version": "1.0.61",
       "license": "ISC",
       "dependencies": {
         "@google-cloud/cloudbuild": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keetapay/pulumi-components",
-  "version": "1.0.60",
+  "version": "1.0.61",
   "description": "KeetaPay Pulumi Components",
   "repository": "https://github.com/keetapay/pulumi-components.git",
   "main": "dist/index.js",


### PR DESCRIPTION
This changeset fixes a couple of bugs related to replication of secretsmanager secrets with the CloudRun EnvManager.

-  Automatic replication isn't allowed, this fixes it
-  Allow specifying multiple regions for secretmanager secret replication

It also releases v1.0.61