### PR TITLE
Export the "PolicyBindingBase" object

### DIFF
--- a/src/packages/gcp/policy.ts
+++ b/src/packages/gcp/policy.ts
@@ -11,7 +11,7 @@ export interface PolicyDataBinding {
 	addMembers(role: string, members: pulumi.Input<string>[]): void;
 }
 
-class PolicyBindingBase {
+export class PolicyBindingBase {
 	private members: { [role: string]: pulumi.Input<string>[] } = {};
 
 	addMembers(role: string, members: pulumi.Input<string>[]) {


### PR DESCRIPTION
This change exports the "PolicyBindingBase" object because it does some useful things for helping generate resource policies which are otherwise a bit of work to implement in some cases.