### PR TITLE
Fix incorrect zones

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@keetapay/pulumi-components",
-  "version": "1.0.62",
+  "version": "1.0.63",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@keetapay/pulumi-components",
-      "version": "1.0.62",
+      "version": "1.0.63",
       "license": "ISC",
       "dependencies": {
         "@google-cloud/cloudbuild": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keetapay/pulumi-components",
-  "version": "1.0.62",
+  "version": "1.0.63",
   "description": "KeetaPay Pulumi Components",
   "repository": "https://github.com/keetapay/pulumi-components.git",
   "main": "dist/index.js",

--- a/src/packages/gcp/constants.ts
+++ b/src/packages/gcp/constants.ts
@@ -80,11 +80,23 @@ export const gcpZones = {
 	'us-east5': ['us-east5-a', 'us-east5-b', 'us-east5-c'],
 	'us-south1': ['us-south1-a', 'us-south1-b', 'us-south1-c'],
 	'us-west1': ['us-west1-a', 'us-west1-b', 'us-west1-c'],
-	'us-west2': ['us-west2-a', 'us-west2-b', 'us-west2-c', 'us-west3-a'],
-	'us-west3': ['us-west3-b', 'us-west3-c'],
+	'us-west2': ['us-west2-a', 'us-west2-b', 'us-west2-c'],
+	'us-west3': ['us-west3-a', 'us-west3-b', 'us-west3-c'],
 	'us-west4': ['us-west4-a', 'us-west4-b', 'us-west4-c']
 } as const;
 export type GCPZone = typeof gcpZones[GCPRegion][number];
+
+/**
+ * Create a static type check that every zone in the gcpZones object is prefixed with the region name
+ */
+type _ignore_static_check_zones1 = {
+	[K in GCPRegion]: typeof gcpZones[K][number] extends `${K}-${string}` ? true : false;
+};
+type _ignore_static_check_zones2 = {
+	[K in GCPRegion]: true;
+};
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const _ignore_static_check_zone1: _ignore_static_check_zones1 extends _ignore_static_check_zones2 ? true : false = true;
 
 export const gcpSpannerRegions = [
 	'northamerica-northeast1',


### PR DESCRIPTION
This change fixes a bug where a zone in `us-west2` was actually a `us-west3` zone, which causes deployment failures.

Additionally, a static check for the correct prefix of each zone was added

This releases pulumi-components v1.0.63.