### PR TITLE
Fix bug where the wrong type is used for "parent" for VPC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@keetapay/pulumi-components",
-  "version": "1.0.64",
+  "version": "1.0.65",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@keetapay/pulumi-components",
-      "version": "1.0.64",
+      "version": "1.0.65",
       "license": "ISC",
       "dependencies": {
         "@google-cloud/cloudbuild": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keetapay/pulumi-components",
-  "version": "1.0.64",
+  "version": "1.0.65",
   "description": "KeetaPay Pulumi Components",
   "repository": "https://github.com/keetapay/pulumi-components.git",
   "main": "dist/index.js",

--- a/src/packages/gcp/vpc.ts
+++ b/src/packages/gcp/vpc.ts
@@ -104,7 +104,7 @@ export function addGooglePrivateIPAccessNetwork(name: string, state: Set<gcp.com
  * @param state The state to apply
  * @param parent The parent resource for the resources
  */
-export function applyGooglePrivateIPAccess(name: string, state: Set<gcp.compute.Network>, parent?: pulumi.ComponentResource) {
+export function applyGooglePrivateIPAccess(name: string, state: Set<gcp.compute.Network>, parent?: pulumi.Resource) {
 	/*
 	 * If there are no networks to apply Google Private IP Access to, then
 	 * we can skip this step


### PR DESCRIPTION
This change fixes a small bug where the "parent" isn't generic enough and releases v1.0.65.