### PR TITLE
Upgrade CI to use NodeJS 18

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v1
         with:
-          node-version: 16.18.1
+          node-version: 18.18.2
           registry-url: 'https://npm.pkg.github.com'
 
       - name: Write private key to .npmrc file


### PR DESCRIPTION
This change upgrades the GitHub Actions to use NodeJS 18.18.2 like the rest of our systems.