### PR TITLE
Support Cloud SQL Query Insights

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@keetapay/pulumi-components",
-	"version": "1.0.73",
+	"version": "1.0.74",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@keetapay/pulumi-components",
-			"version": "1.0.73",
+			"version": "1.0.74",
 			"license": "ISC",
 			"dependencies": {
 				"@google-cloud/cloudbuild": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keetapay/pulumi-components",
-	"version": "1.0.73",
+	"version": "1.0.74",
 	"description": "KeetaPay Pulumi Components",
 	"repository": "https://github.com/keetapay/pulumi-components.git",
 	"main": "dist/index.js",

--- a/src/packages/gcp/sql.ts
+++ b/src/packages/gcp/sql.ts
@@ -192,6 +192,11 @@ export interface PostgresCloudSQLArgs {
 	 * @default true
 	 */
 	abandonOnDelete?: boolean;
+
+	/**
+	 * Query Insights options
+	 */
+	insightsConfig?: NonNullable<pulumi.Unwrap<ConstructorParameters<typeof gcp.sql.DatabaseInstance>[1]['settings']>>['insightsConfig'];
 }
 
 type PostgresURLParams = {
@@ -431,10 +436,18 @@ export class PostgresCloudSQL extends pulumi.ComponentResource {
 					ipv4Enabled: false,
 					privateNetwork: this.#vpcNetwork.id,
 					// This is named badly on pulumi's side
-					requireSsl: this.#options.tls?.requireClientCertificate
+					requireSsl: this.#options.tls?.requireClientCertificate,
+					sslMode: 'ENCRYPTED_ONLY'
 				},
 				databaseFlags: databaseFlags,
-				backupConfiguration: backupConfiguration
+				backupConfiguration: backupConfiguration,
+				insightsConfig: this.#options.insightsConfig ?? {
+					queryInsightsEnabled: false,
+					queryPlansPerMinute: 0,
+					queryStringLength: 0,
+					recordApplicationTags: false,
+					recordClientAddress: false
+				}
 			}
 		}, { protect: deletionProtection, ...options });
 


### PR DESCRIPTION
After upgrading to the latest `@pulumi/gcp` package we can now set the Cloud SQL Insights Configuration as well as enforce TLS-only connections.

This change enacts those changes as well as releases v1.0.74.