### PR TITLE
Add more options to Managed Instance Groups

### DIFF
--- a/src/packages/gcp/container.ts
+++ b/src/packages/gcp/container.ts
@@ -211,10 +211,11 @@ export class ContainerMIG extends pulumi.ComponentResource {
 		const containerSpec = {
 			...options.containerSpec,
 			containers: options.containerSpec.containers.map(function(container) {
-				const { registry, ...containerSpec } = container;
-				return(containerSpec);
+				// eslint-disable-next-line @typescript-eslint/no-unused-vars
+				const { registry: _ignore_registry, ...newContainerSpec } = container;
+				return(newContainerSpec);
 			})
-		}
+		};
 
 		/**
 		 * Run commands to execute on the VMs when they start up


### PR DESCRIPTION
This change adds a couple of new options to Managed Instance Groups:

1. Enable SSH on the VM (for debugging)
2. Allow Zonal Instance Groups (in addition to Regional ones)
3. Add IAM permissions to artifact registry registries
