### PR TITLE
Fix: Prefix Issue with API Routes

### DIFF
--- a/src/packages/gcp/apps.ts
+++ b/src/packages/gcp/apps.ts
@@ -89,6 +89,7 @@ interface RouteRuleConfig {
 	routeAction?: {
 		urlRewrite?: {
 			pathTemplateRewrite?: string;
+			pathPrefixRewrite?: string;
 		};
 	};
 }
@@ -1246,7 +1247,12 @@ export class FullStackApp extends pulumi.ComponentResource {
 				{
 					priority: staticPaths.length + staticFiles.length + 1,
 					matchRules: [{ prefixMatch: apiPrefix }],
-					service: this.backend.backendService.id
+					service: this.backend.backendService.id,
+					routeAction: {
+						urlRewrite: {
+							pathPrefixRewrite: '/'
+						}
+					}
 				},
 				{
 					priority: staticPaths.length + staticFiles.length + 2,


### PR DESCRIPTION
# Summary

Add pathPrefixRewrite: '/' to the URL map's API route rule so that requests matching the apiPrefix (e.g., /api/logger) have the prefix stripped before being forwarded to the Cloud Run backend (e.g., /logger). 

Without this, the backend received the full prefixed path and returned 404 since it registers routes without the prefix.