### PR TITLE
Fix issue with fixing kv name length 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@keetanetwork/pulumi-components",
-	"version": "1.0.83",
+	"version": "1.0.84",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@keetanetwork/pulumi-components",
-			"version": "1.0.83",
+			"version": "1.0.84",
 			"license": "ISC",
 			"dependencies": {
 				"@google-cloud/cloudbuild": "5.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keetanetwork/pulumi-components",
-	"version": "1.0.83",
+	"version": "1.0.84",
 	"description": "KeetaNetwork Pulumi Components",
 	"repository": "https://github.com/keetanetwork/pulumi-components.git",
 	"main": "dist/index.js",

--- a/src/packages/gcp/apps.ts
+++ b/src/packages/gcp/apps.ts
@@ -872,7 +872,7 @@ export class CloudRunService extends pulumi.ComponentResource {
 			}
 
 			if (args.kv) {
-				kv = new gcp.redis.Instance(generateName(name, 'kv', 33), {
+				kv = new gcp.redis.Instance(generateName(name, 'kv', 32), {
 					authEnabled: true,
 					authorizedNetwork: vpc.id,
 					region: args.region,

--- a/src/packages/gcp/apps.ts
+++ b/src/packages/gcp/apps.ts
@@ -872,7 +872,7 @@ export class CloudRunService extends pulumi.ComponentResource {
 			}
 
 			if (args.kv) {
-				kv = new gcp.redis.Instance(generateName(name, 'kv', 38), {
+				kv = new gcp.redis.Instance(generateName(name, 'kv', 33), {
 					authEnabled: true,
 					authorizedNetwork: vpc.id,
 					region: args.region,


### PR DESCRIPTION
Previous pr #96 did not set the max length low enough for the kv name since pulumi adds an additional 8 characters to the name. This PR lowers the value to be correct