### PR TITLE
v1.0.87: Allow specifying Content-Type on files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@keetanetwork/pulumi-components",
-	"version": "1.0.86",
+	"version": "1.0.87",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@keetanetwork/pulumi-components",
-			"version": "1.0.86",
+			"version": "1.0.87",
 			"license": "ISC",
 			"dependencies": {
 				"@google-cloud/cloudbuild": "5.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keetanetwork/pulumi-components",
-	"version": "1.0.86",
+	"version": "1.0.87",
 	"description": "KeetaNetwork Pulumi Components",
 	"repository": "https://github.com/keetanetwork/pulumi-components.git",
 	"main": "dist/index.js",

--- a/src/packages/gcp/apps.ts
+++ b/src/packages/gcp/apps.ts
@@ -297,7 +297,12 @@ export interface StaticWebAppArgs {
 	/**
 	 * Optional filter for files to upload
 	 */
-	fileFilter?: (file: string) => boolean;
+	fileFilter?: ConstructorParameters<typeof GoogleCloudFolderWithArgs>[1]['filter'];
+
+	/**
+	 * Optional function to compute content type for uploaded files
+	 */
+	computeContentType?: ConstructorParameters<typeof GoogleCloudFolderWithArgs>[1]['computeContentType'];
 
 	/**
 	 * Cache control options for uploaded files
@@ -395,6 +400,7 @@ export class StaticWebApp extends pulumi.ComponentResource {
 			bucketName: bucket.name,
 			path: args.staticFilesPath,
 			filter: args.fileFilter,
+			computeContentType: args.computeContentType,
 			options: {
 				generated: function(fileName: string) {
 					let ttl: number;


### PR DESCRIPTION
This change adds support for FullStackApp and StaticWebApp to be able to specify a content-type on a per-file basis (needed for the "apple-app-site-association" files which are JSON but have no file extension to guess this type from